### PR TITLE
[Feature victory line] - Ajout de la fonction pour dessiner une ligne de victoire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ### Projects2024
-Projets des étudiants en BUT Info 2024-2025
+Projets de Bastien DESHAYES, Antoine SOULAT, Arthur GRAMONT & Louis PADÉ
 
 # Projet de Développement de Jeux 
 ## Langage de programmation au choix
-Date de Remise : 31/11/2024 à 23h59 – MAX
+Date de Remise : 1/3/2025 à 23h59 – MAX
 
 Chaque jour de retard entrainera une pénalité.
 

--- a/morpion.py
+++ b/morpion.py
@@ -46,6 +46,19 @@ def dessiner_O(ligne, col):
     rayon = squareSize // 3
     pygame.draw.circle(ecran, oColor, (centre_x, centre_y), rayon, lineWidth)
 
+def dessiner_ligne_victoire(joueur, ligne, col, direction):
+    couleur = victoryColor
+    if direction == "horizontal":
+        y = ligne * squareSize + squareSize // 2
+        pygame.draw.line(ecran, couleur, (20, y), (screenSize - 20, y), lineWidth)
+    elif direction == "vertical":
+        x = col * squareSize + squareSize // 2
+        pygame.draw.line(ecran, couleur, (x, 20), (x, screenSize - 20), lineWidth)
+    elif direction == "diag1":
+        pygame.draw.line(ecran, couleur, (20, 20), (screenSize - 20, screenSize - 20), lineWidth)
+    elif direction == "diag2":
+        pygame.draw.line(ecran, couleur, (screenSize - 20, 20), (20, screenSize - 20), lineWidth)
+
 def verifier_victoire(joueur):
     for ligne in range(3):
         if plateau[ligne][0] == plateau[ligne][1] == plateau[ligne][2] == joueur:


### PR DESCRIPTION
Cette pull request ajoute une nouvelle fonctionnalité au jeu de morpion : la possibilité d'afficher une ligne de victoire lorsqu'un joueur gagne.

- La fonction dessiner_ligne_victoire utilise pygame pour tracer une ligne colorée sur la grille, indiquant la direction de la victoire
- Les paramètres permettent de déterminer la position et la direction de la ligne